### PR TITLE
fixes sticky nav error and page jump

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6,6 +6,9 @@ var createStickyNav = function($node, reqAnimFrame, className) {
 	var isSticky;
 	var lastPos = -1;
 	var stickyTop = ~~($node.offset().top);
+	var $clone = $node.clone();
+
+	$clone.insertAfter($node).hide();
 
 	var loop = function() {
 		reqAnimFrame(loop);
@@ -17,8 +20,7 @@ var createStickyNav = function($node, reqAnimFrame, className) {
 		if (_isSticky === isSticky) return;
 		isSticky = _isSticky;
 		lastPos = pos;
-		$node.toggleClass(className, isSticky);
-
+		$clone.toggle(isSticky).toggleClass(className, isSticky);
 	};
 
 	loop();
@@ -28,6 +30,8 @@ $(function() {
 
   // Sticky that nav up
   var $nav = $('.js-sticky-nav')
-  createStickyNav($nav, window.requestAnimationFrame)
+  if ($nav.length) {
+	  createStickyNav($nav, window.requestAnimationFrame)
+	}
 
 })

--- a/js/app.js
+++ b/js/app.js
@@ -27,11 +27,9 @@ var createStickyNav = function($node, reqAnimFrame, className) {
 };
 
 $(function() {
-
-  // Sticky that nav up
-  var $nav = $('.js-sticky-nav')
-  if ($nav.length) {
-	  createStickyNav($nav, window.requestAnimationFrame)
+	// Sticky that nav up
+	var $nav = $('.js-sticky-nav')
+	if ($nav.length) {
+		createStickyNav($nav, window.requestAnimationFrame)
 	}
-
 })


### PR DESCRIPTION
On the home page when nav becomes sticky there is a page jump the size of the nav, since it become fixed. This makes that transition a little more smooth. Also, I notice on ever page except for the home page there was an error thrown since `$nav` didn't exists. 
