### PR TITLE
add wwwtf news

### DIFF
--- a/_posts/2015-08-17-wwwtf.md
+++ b/_posts/2015-08-17-wwwtf.md
@@ -1,0 +1,13 @@
+---
+layout: post
+title: Ticket Sale for JSConf EU 2015
+category: news
+tags: news
+figure: /img/what-next.jpg
+dateOverride: 17 August 2015
+---
+
+{% include post-header.html %}
+Good news! We will have a full week of exciting events for and by the Web Tech community in Berlin! Everyone is invited to bring their own event and there is already a huge amount of events listed at [http://wwwtf.berlin/](http://wwwtf.berlin/).
+
+We are looking forward to meet you all in September!


### PR DESCRIPTION
Hey,

we've been talking at OTSConf about the wwwtf berlin and that it is somehow hard to find and small. We started a small working group to fix the issues.

I first wanted to add a link to the jsconf.eu page, but after taking a closer look at the web site I decided for a news article. 

All the best from OTS Conf!
