### PR TITLE
Link to 2015 schedule instead of the one from last year

### DIFF
--- a/_includes/schedule.md
+++ b/_includes/schedule.md
@@ -1,5 +1,5 @@
 
-<p>Looking for the talk schedule? Links to various versions are <a href="/news/2014/09/09/the-schedule.html">here</a>.</p>
+<p>Looking for the talk schedule? Links to various versions are <a href="/news/2015/09/14/talk-schedule/">here</a>.</p>
 
 <p>
   For even more JavaScript-related goodness, make sure to check out the week-long <b><a href="http://jsfest.berlin/">jsfest.berlin</a></b> in the days around JSConf.


### PR DESCRIPTION
Link to http://2015.jsconf.eu/news/2015/09/14/talk-schedule/ instead of last year’s schedule page.
