### PR TITLE
Add Web Rebels to list of JSConfs going on in 2016

### DIFF
--- a/_posts/2016-01-05-announcing-jsconfeu-2017.md
+++ b/_posts/2016-01-05-announcing-jsconfeu-2017.md
@@ -27,6 +27,7 @@ But don’t despair! There are A LOT of JSConfs going on in 2016, you just have 
 - [JSConf Uruguay](https://jsconf.uy)
 - [JSConf Belgium](http://jsconf.be/)
 - [JSConf Asia](http://jsconf.asia)
+- [Web Rebels](https://www.webrebels.org/)
 
 * * *
 


### PR DESCRIPTION
Since we are part of the the JSConf Family Of Events http://jsconf.com/#family I thought it would be inline to suggest naming us in this list. If not please decline this pull request.
